### PR TITLE
LEARNER-4692 Test - iOS - Automate new Landing Screen

### DIFF
--- a/common/globals.py
+++ b/common/globals.py
@@ -42,6 +42,7 @@ class Globals(object):
         self.target_environment = environ.get('TARGET_ENVIRONMENT')
         self.login_user_name = environ.get('LOGIN_USER_NAME')
         self.login_password = environ.get('LOGIN_PASSWORD')
+        self.new_landing_search_courses = 'python'
 
         # CAPABILITIES
         self.ios_platform_version = environ.get('IOS_PLATFORM_VERSION')

--- a/common/strings.py
+++ b/common/strings.py
@@ -77,3 +77,9 @@ REGISTER_SCREEN_REGISTER_WITH = 'Register with'
 # DISCOVERY SCREEN
 DISCOVER_COURSES_SCREEN_TITLE = 'Discover'
 DISCOVER_CANCEL = 'Cancel'
+
+# NEW LANDING SCREEN
+NEW_LANDING_MESSAGE = 'Free courses from the world\'s best universities in your pocket.'
+NEW_LANDING_SEARCH_COURSES = 'Search Courses'
+NEW_LANDING_CREATE_YOUR_ACCOUNT = 'Create your Account'
+NEW_LANDING_LOG_IN = 'Log In'

--- a/ios/pages/ios_base_page.py
+++ b/ios/pages/ios_base_page.py
@@ -18,3 +18,4 @@ class IosBasePage(object):
         self.textview_drawer_account_option = None
         self.account_options = None
         self.LOGOUT_OPTION = 3
+        self.discovery_cancel_button = None

--- a/ios/pages/ios_elements.py
+++ b/ios/pages/ios_elements.py
@@ -53,3 +53,10 @@ register_create_my_account_button = 'RegistrationViewController:register-button'
 # DISCOVERY SCREEN
 discovery_close_button = 'Cancel'
 discover_courses_title_textview = 'Discover'
+
+# NEW LANDING SCREEN
+new_landing_logo = 'StartUpViewController:logo-image-view'
+new_landing_welcome_message = 'StartUpViewController:message-label'
+new_landing_search_courses_editfield = 'StartUpViewController:search-textfield'
+new_landing_log_in_button = 'StartUpViewController:sign-in-button'
+new_landing_register_button = 'StartUpViewController:register-button'

--- a/ios/pages/ios_new_landing.py
+++ b/ios/pages/ios_new_landing.py
@@ -1,0 +1,178 @@
+"""
+    New Landing Page Module
+"""
+from selenium.webdriver.common.keys import Keys
+
+from common import strings
+from ios.pages import ios_elements
+from ios.pages.ios_base_page import IosBasePage
+
+
+class IosNewLanding(IosBasePage):
+    """
+    New Landing screen
+    """
+
+    def get_edx_logo(self):
+        """
+        Get edX logo
+
+        Returns:
+            webdriver element: Logo element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.new_landing_logo
+        )
+
+    def get_welcome_message(self):
+        """
+        Get welcome message text
+
+        Returns:
+            webdriver element: Welcome Message element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.new_landing_welcome_message
+        )
+
+    def get_search_course_editfield(self):
+        """
+        Get Search Courses edit field
+
+        Returns:
+            webdriver element: Search Courses element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.new_landing_search_courses_editfield
+        )
+
+    def get_register_button(self):
+        """
+        Get Register Button
+
+        Returns:
+            webdriver element: Register Button element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.new_landing_register_button
+        )
+
+    def get_signin_button(self):
+        """
+        Get Login Button
+
+        Returns:
+            webdriver element: Login Button element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.new_landing_log_in_button
+        )
+
+    def load_login_screen(self):
+        """
+        Load Login Screen
+
+        Returns:
+             webdriver element: Login screen Title element
+        """
+
+        self.get_signin_button().click()
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.login_signin_button
+        )
+
+    def load_register_screen(self):
+        """
+        Load Register Screen
+
+        Returns:
+             webdriver element: Register screen Title element
+        """
+
+        self.get_register_button().click()
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.register_with_textview
+        )
+
+    def search_courses(self, course_name):
+        """
+        Search some Course and load Discovery Screen
+
+        Arguments:
+            course_name (str): course name
+
+        Returns:
+            webdriver element: Cancel Element
+        """
+
+        search_courses = self.get_search_course_editfield()
+        search_courses.clear()
+        search_courses.send_keys(course_name)
+        search_courses.send_keys(Keys.ENTER)
+        self.discovery_cancel_button = self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.discovery_close_button
+        )
+
+        return self.discovery_cancel_button
+
+    def cancel_discovery_screen(self):
+        """
+        Close/Cancel Discovery Screen
+        """
+
+        self.discovery_cancel_button.click()
+
+    def back_and_forth_login(self):
+        """
+        Load login screen and get back to previous screen
+
+        Returns:
+             bool: Returns True if app is back on New Landing screen from Login screen
+        """
+
+        if self.load_login_screen().text == strings.LOGIN:
+            login_close_button = self.global_contents.wait_and_get_element(
+                self.driver,
+                ios_elements.login_close_button
+            )
+            login_close_button.click()
+
+            return self.get_welcome_message().text == strings.NEW_LANDING_MESSAGE
+
+        else:
+            self.log.info('Problem - Login screen is not loaded')
+            return False
+
+    def back_and_forth_register(self):
+        """
+        Load register screen and get back to previous screen
+
+        Returns:
+             bool: Returns True if app is back on New Landing screen from Register screen
+        """
+
+        if self.load_register_screen().text == strings.REGISTER_SCREEN_REGISTER_WITH:
+            register_close_button = self.global_contents.wait_and_get_element(
+                self.driver,
+                ios_elements.register_close_button
+            )
+            register_close_button.click()
+
+            return self.get_welcome_message().text == strings.NEW_LANDING_MESSAGE
+
+        else:
+            self.log.info('Problem - Register screen is not loaded')
+            return False

--- a/ios/tests/test_ios_new_landing.py
+++ b/ios/tests/test_ios_new_landing.py
@@ -1,0 +1,68 @@
+"""
+    New Landing Test Module
+"""
+
+from common import strings
+from common.globals import Globals
+from ios.pages.ios_new_landing import IosNewLanding
+
+
+class TestIosNewLanding(object):
+    """
+    New Landing screen's Test Case
+    """
+
+    def test_start_new_landing_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify New Landing screen is loaded successfully
+        """
+
+        setup_logging.info('-- Starting {} Test Case'.format(TestIosNewLanding.__name__))
+
+        ios_new_landing = IosNewLanding(set_capabilities, setup_logging)
+        assert ios_new_landing.get_welcome_message().text == strings.NEW_LANDING_MESSAGE
+
+    def test_ui_elements_smoke(self, set_capabilities, setup_logging):
+        """
+        Verify following contents are visible on screen, 
+            "edX logo", "Message" text-field, "Search Courses" edit-field, "Register" button, "Sign In" button
+        Verify all contents have their default values
+        """
+
+        ios_new_landing = IosNewLanding(set_capabilities, setup_logging)
+
+        assert ios_new_landing.get_edx_logo().text == strings.LOGIN_EDX_LOGO
+        assert ios_new_landing.get_welcome_message().text == strings.NEW_LANDING_MESSAGE
+        assert ios_new_landing.get_search_course_editfield().text == strings.NEW_LANDING_SEARCH_COURSES
+        assert ios_new_landing.get_signin_button().text == strings.NEW_LANDING_LOG_IN
+        assert ios_new_landing.get_register_button().text == strings.NEW_LANDING_CREATE_YOUR_ACCOUNT
+
+    def test_search_courses_smoke(self, set_capabilities, setup_logging):
+        """
+        Verifies that user can search courses, and back to New Landing screen
+        """
+
+        global_contents = Globals(setup_logging)
+        ios_new_landing = IosNewLanding(set_capabilities, setup_logging)
+        search_courses = ios_new_landing.search_courses(global_contents.new_landing_search_courses).text
+        assert search_courses == strings.DISCOVER_CANCEL
+        ios_new_landing.cancel_discovery_screen()
+        assert ios_new_landing.get_welcome_message().text == strings.NEW_LANDING_MESSAGE
+
+    def test_back_and_forth_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+                Verify tapping "Login" will load "Sign In" screen
+                Verify tapping back/cross icon from 'Sign In' screen navigate user
+                    back to 'New Landing' screen
+                Verify tapping "Create your Account" loads "Register" screen
+                Verify tapping back/cross icon from "Register" screen
+                    navigate user back to 'New Landing' screen
+        """
+
+        ios_new_landing = IosNewLanding(set_capabilities, setup_logging)
+        assert ios_new_landing.back_and_forth_login()
+        assert ios_new_landing.back_and_forth_register()
+
+        setup_logging.info('-- Ending {} Test Case'.format(TestIosNewLanding.__name__))


### PR DESCRIPTION
Following scenarios are covered,
* Verify that Landing screen is loaded successfully
* Verify that Landing screen has following contents,
** edX logo
** Description text-field
** Search Courses edit-field
** Register button
** Sign In button
* Verify that all elements have their default values
* Verify that tapping "Log In" loads Log In screen
* Verify that tapping back icon from "Log In" screen navigate user back to Landing screen
* Verify that tapping "Create Your Account" loads Register screen
* Verify that tapping back icon from "Register" screen navigate user back to Landing screen
* Verify that tapping search after entering <course name> should load "Discovery" screen
* Verify that Discovery screen is showing
* Verify tapping back icon from 'Discovery' screen navigate user back to Landing screen