### PR TITLE
LEARNER-5191 Test - Android - Add a Login test case, verify that app shows proper error msg/dialog when user try to login with wrong credentials

### DIFF
--- a/android/pages/android_login.py
+++ b/android/pages/android_login.py
@@ -284,7 +284,7 @@ class AndroidLogin(AndroidBasePage):
             )
             wrong_credentials_alert_ok.click()
 
-            return False, None
+            return False
 
         else:
             if is_first_time:

--- a/android/tests/test_android_login.py
+++ b/android/tests/test_android_login.py
@@ -51,7 +51,7 @@ class TestAndroidLogin(object):
         assert login_with_email_divider == strings.LOGIN_ANDROID_WITH_EMAIL_DIVIDER
         assert android_login_page.get_facebook_textview().text == strings.FACEBOOK_OPTION
         assert android_login_page.get_google_textview().text == strings.GOOGLE_OPTION
-        assert android_login_page.get_agreement_textview().text == strings.LOGIN_AGREEMENT
+        assert android_login_page.get_agreement_textview().text == strings.LOGIN_ANDROID_AGREEMENT
 
     def test_back_and_forth_smoke(self, set_capabilities, setup_logging):
         """
@@ -97,10 +97,13 @@ class TestAndroidLogin(object):
         global_contents = Globals(setup_logging)
         android_login_page = AndroidLogin(set_capabilities, setup_logging)
 
+        assert android_login_page.login(
+            global_contents.login_wrong_user_name,
+            global_contents.login_wrong_password) is False
+
         login_output = android_login_page.login(
             global_contents.login_user_name,
-            global_contents.login_password,
-            True)
+            global_contents.login_password)
         assert login_output == Globals.WHATS_NEW_ACTIVITY_NAME
         setup_logging.info('{} is successfully logged in'.format(global_contents.login_user_name))
         setup_logging.info('-- Ending {} Test Case'.format(TestAndroidLogin.__name__))

--- a/common/globals.py
+++ b/common/globals.py
@@ -56,6 +56,8 @@ class Globals(object):
         self.target_environment = environ.get('TARGET_ENVIRONMENT')
         self.login_user_name = environ.get('LOGIN_USER_NAME')
         self.login_password = environ.get('LOGIN_PASSWORD')
+        self.login_wrong_user_name = 'wrong username'
+        self.login_wrong_password = 'worng password'
         self.new_landing_search_courses = 'python'
 
         # CAPABILITIES

--- a/common/strings.py
+++ b/common/strings.py
@@ -38,16 +38,22 @@ LOGIN_ANDROID_WITH_EMAIL_DIVIDER = 'Or sign in with'
 LOGIN_FACEBOOK_OPTION = 'Register with Facebook'  # 'Facebook'
 LOGIN_GOOGLE_OPTION = 'Register with Google'  # 'Google'
 LOGIN_RESET_PASSWORD_ALERT_TITLE = 'Reset Password'
-LOGIN_RESET_PASSWORD_ALERT_MSG = ('Enter the e-mail address for your account, and we’ll '
-                                  'send you instructions to reset your password.')
+LOGIN_RESET_PASSWORD_ALERT_MSG = ('Enter the e-mail address for your account, '
+                                  'and we’ll send you instructions to reset your password.')
 LOGIN_RESET_PASSWORD_ALERT_OK = 'OK'
 LOGIN_RESET_PASSWORD_ALERT_CANCEL = 'Cancel'
 LOGIN_WRONG_CREDENTIALS_ALERT_TITLE = 'Sign-in Error'
 LOGIN_WRONG_CREDENTIALS_ALERT_MSG = ('Please make sure that your user name or e-mail'
                                      ' address and password are correct and try again.')
 LOGIN_WRONG_CREDENTIALS_ALERT_OK = 'OK'
-LOGIN_AGREEMENT = ('By signing in to this app, you agree to the edX End User License Agreement and edX Terms '
-                   'of Service and Honor Code and acknowledge the Privacy Policy')
+LOGIN_ANDROID_AGREEMENT = ('By signing in to this app, you agree to the edX End User License Agreement and edX Terms '
+                           'of Service and Honor Code and acknowledge the Privacy Policy')
+LOGIN_IOS_AGREEMENT = ('By signing-in to this app, you agree to the edX End User License Agreement and edX Terms '
+                       'of Service and Honor Code and acknowledge the Privacy Policy')
+
+LOGIN_EULA = 'edX End User License Agreement'
+LOGIN_TERMS = 'edX Terms of Service and Honor Code'
+LOGIN_PRIVACY = 'Privacy Policy'
 
 # WHATS NEW SCREEN
 # Issue between iOS and Android

--- a/ios/tests/test_ios_login.py
+++ b/ios/tests/test_ios_login.py
@@ -54,10 +54,10 @@ class TestIosLogin(object):
         assert ios_login_page.get_login_with_email_divider_textview().text == strings.LOGIN_IOS_WITH_EMAIL_DIVIDER
         assert ios_login_page.get_facebook_textview().text == strings.LOGIN_FACEBOOK_OPTION
         assert ios_login_page.get_google_textview().text == strings.LOGIN_GOOGLE_OPTION
-        assert ios_login_page.get_agreement_textview().text == strings.LOGIN_AGREEMENT
-        assert ios_login_page.get_eula_textview().text == strings.EULA
-        assert ios_login_page.get_terms_textview().text == strings.TERMS
-        assert ios_login_page.get_privacy_textview().text == strings.PRIVACY
+        assert ios_login_page.get_agreement_textview().text == strings.LOGIN_IOS_AGREEMENT
+        assert ios_login_page.get_eula_textview().text == strings.LOGIN_EULA
+        assert ios_login_page.get_terms_textview().text == strings.LOGIN_TERMS
+        assert ios_login_page.get_privacy_textview().text == strings.LOGIN_PRIVACY
 
     def test_load_agreement_smoke(self, set_capabilities, setup_logging):
         """


### PR DESCRIPTION
Following cases is handled,

* Verify that app shows proper error msg/dialog when user try to login with followings,
** wrong Username
** wrong Password