### PR TITLE
LEARNER-4466 Test - iOS - Add more smoke cases in Login Test Case

### DIFF
--- a/ios/pages/ios_elements.py
+++ b/ios/pages/ios_elements.py
@@ -19,7 +19,7 @@ login_close_button = 'LoginViewController:close-bar-button-item'
 login_edx_logo = 'LoginViewController:logo-image-view'
 login_user_name_editfield = 'LoginViewController:email-text-field'
 login_password_editfield = 'LoginViewController:password-text-field'
-login_forget_password_textview = 'LoginViewController:trouble-logging-button'
+login_forgot_password_textview = 'LoginViewController:trouble-logging-button'
 login_signin_button = 'LoginViewController:login-button'
 login_signin_divider_textview = 'LoginViewController:sign-in-label'
 login_facebook_textview = 'ExternalAuthOptionsView:facebook-button'
@@ -30,6 +30,17 @@ login_eula_textview = 'edX End User License Agreement'
 login_terms_textview = 'edX Terms of Service and Honor Code'
 login_privacy_textview = 'Privacy Policy'
 login_agreement_close = 'OEXUserLicenseAgreementViewController:close-button'
+# Accessing elements on visible contents untill following ticket is processed
+# [LEARNER-5086 iOS - Login Screen - Forgot Password Alert - unique ids are not assigned]
+login_reset_password_alert_title = 'Reset Password'
+login_reset_password_alert_msg = ("Enter the e-mail address for your account, "
+                                  "and we'll send you instructions to reset your password.")
+login_reset_password_alert_email_editfield = 'XCUIElementTypeTextField'
+login_reset_password_alert_ok_button = 'OK'
+login_reset_password_alert_cancel_button = 'Cancel'
+
+# TERMS & CONDITIONS
+terms_close_button = 'Close'
 
 # WHATS NEW SCREEN
 whats_new_title_textview = 'WhatsNewViewController:header-label'

--- a/ios/pages/ios_login.py
+++ b/ios/pages/ios_login.py
@@ -1,9 +1,10 @@
 """
     Login Page Module
 """
-
+from common import strings
 from ios.pages import ios_elements
 from ios.pages.ios_base_page import IosBasePage
+from ios.pages.ios_new_landing import IosNewLanding
 from ios.pages.ios_whats_new import IosWhatsNew
 
 
@@ -86,17 +87,17 @@ class IosLogin(IosBasePage):
             ios_elements.login_password_editfield
         )
 
-    def get_forget_password_textview(self):
+    def get_forgot_password_textview(self):
         """
-        Get Forget Password
+        Get Forgot Password
 
         Returns:
-             webdriver element: Forget Password Element
+             webdriver element: Forgot Password Element
         """
 
         return self.global_contents.wait_and_get_element(
             self.driver,
-            ios_elements.login_forget_password_textview
+            ios_elements.login_forgot_password_textview
         )
 
     def get_sign_in_button(self):
@@ -283,3 +284,132 @@ class IosLogin(IosBasePage):
                 ios_elements.main_dashboard_navigation_icon
             )
         return textview_screen_title
+
+    def back_and_forth_new_landing(self):
+        """
+        From Login screen tapping back will load New Landing screen and tapping Login will
+            load Login screen
+
+        Returns:
+             bool: Returns True if app is back on Login screen from New Landing screen
+        """
+
+        ios_new_landing = IosNewLanding(self.driver, self.log)
+
+        if self.on_screen().text == strings.LOGIN:
+            self.global_contents.flag = True
+            self.driver.back()
+            if ios_new_landing.load_login_screen() == strings.LOGIN:
+                self.global_contents.flag = True
+            else:
+                self.log.error('Problem - New Landing screen is not loaded')
+                self.global_contents.flag = False
+        else:
+            self.log.info('Problem - Login screen is not loaded')
+            self.global_contents.flag = False
+
+        return self.global_contents.flag
+
+    def back_and_forth_terms(self):
+        """
+        From Login screen tapping 'edX Terms of Service...' will load Terms & Conditions screen
+            and tapping back will load Login screen
+
+        Returns:
+             bool: Returns True if app is back on Login screen from edX Terms of Service
+        """
+
+        if self.on_screen().text == strings.LOGIN:
+            self.global_contents.flag = True
+            self.get_terms_textview().click()
+
+            self.global_contents.wait_and_get_element(
+                self.driver,
+                ios_elements.terms_close_button).click()
+            if self.on_screen().text == strings.LOGIN:
+                self.global_contents.flag = True
+            else:
+                self.log.error('Problem - Terms screen is not loaded')
+                self.global_contents.flag = False
+        else:
+            self.log.info('Problem - Login screen is not loaded')
+            self.global_contents.flag = False
+
+        return self.global_contents.flag
+
+    def get_forgot_password_alert(self):
+        """
+        Load forgot Password alert
+
+        Returns:
+             webdriver element: alert element
+        """
+
+        self.get_forgot_password_textview().click()
+        return self.driver.find_element_by_id(ios_elements.login_reset_password_alert_title)
+
+    def get_forgot_password_alert_title(self):
+        """
+        Get alert's title element on Forgot Password Alert
+
+        Returns:
+             webdriver element: alert title element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.login_reset_password_alert_title
+        )
+
+    def get_forgot_password_alert_msg(self):
+        """
+        Get alert message element on Forgot Password Alert
+
+        Returns:
+             webdriver element: message element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.login_reset_password_alert_msg
+        )
+
+    def get_forgot_password_alert_ok_button(self):
+        """
+        Get OK button element on Forgot Password Alert
+
+        Returns:
+             webdriver element: OK element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.login_reset_password_alert_ok_button
+        )
+
+    def get_forgot_password_alert_cancel_button(self):
+        """
+        Get Cancel button element on Forgot Password Alert
+
+        Returns:
+             webdriver element: CANCEL element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.login_reset_password_alert_cancel_button
+        )
+
+    def close_forgot_password_alert(self):
+        """
+        Close forgot password alert
+
+        Returns:
+             bool: True if alert is closed, False if alert is not closed
+        """
+
+        self.get_forgot_password_alert_cancel_button().click()
+        return self.global_contents.wait_for_element_invisibility(
+            self.driver,
+            ios_elements.login_reset_password_alert_cancel_button
+        )

--- a/ios/tests/test_ios_login.py
+++ b/ios/tests/test_ios_login.py
@@ -49,7 +49,7 @@ class TestIosLogin(object):
         assert ios_login_page.get_logo().text == strings.LOGIN_EDX_LOGO
         assert ios_login_page.get_username_editfield().text == strings.LOGIN_USER_NAME_WATER_MARK
         assert ios_login_page.get_password_editfield().text == strings.LOGIN_PASSWORD_WATER_MARK
-        assert ios_login_page.get_forget_password_textview().text == strings.LOGIN_FORGOT_PASSWORD
+        assert ios_login_page.get_forgot_password_textview().text == strings.LOGIN_FORGOT_PASSWORD
         assert ios_login_page.get_sign_in_button().text == strings.LOGIN
         assert ios_login_page.get_login_with_email_divider_textview().text == strings.LOGIN_IOS_WITH_EMAIL_DIVIDER
         assert ios_login_page.get_facebook_textview().text == strings.LOGIN_FACEBOOK_OPTION
@@ -71,6 +71,38 @@ class TestIosLogin(object):
         assert ios_login_page.load_eula_screen().text == strings.LOGIN
         assert ios_login_page.load_terms_screen().text == strings.LOGIN
         assert ios_login_page.load_privacy_screen().text == strings.LOGIN
+
+    def test_back_and_forth_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+                Verify tapping back icon from 'Sign In' screen navigate user back to 'New Landing' screen.
+                Verify tapping "edX Terms of Service and Honor Code" loads "End User License Agreement" screen
+                Verify tapping back icon from "End User License Agreement" screen navigate user
+                back to 'Sign In' screen.
+        """
+
+        ios_login_page = IosLogin(set_capabilities, setup_logging)
+        ios_login_page.back_and_forth_new_landing()
+        ios_login_page.back_and_forth_terms()
+
+    def test_forgot_password_alert(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+                Verify tapping 'Forgot your password?' will  load 'Reset Password' alert
+                Verify following contents are visible on 'Reset Password' alert, 
+                Alert Title, Alert Message, Email edit field, Cancel & OK buttons
+                Verify tapping 'Cancel' will close 'Reset Password' alert
+        """
+
+        ios_login_page = IosLogin(set_capabilities, setup_logging)
+        ios_login_page.get_forgot_password_alert()
+
+        assert ios_login_page.get_forgot_password_alert_title().text == strings.LOGIN_RESET_PASSWORD_ALERT_TITLE
+        assert ios_login_page.get_forgot_password_alert_msg().text == strings.LOGIN_RESET_PASSWORD_ALERT_MSG
+        assert ios_login_page.get_forgot_password_alert_ok_button().text == strings.LOGIN_RESET_PASSWORD_ALERT_OK
+        forgot_password_alert_cancel_button = ios_login_page.get_forgot_password_alert_cancel_button().text
+        assert forgot_password_alert_cancel_button == strings.LOGIN_RESET_PASSWORD_ALERT_CANCEL
+        assert ios_login_page.close_forgot_password_alert()
 
     def test_login_smoke(self, set_capabilities, setup_logging):
         """


### PR DESCRIPTION
Following scenarios has been handled in Login Test Case,

* Verify tapping back icon from 'Sign In' screen navigate user back to 'New Logistration' screen.
* Verify tapping "edX Terms of Service and Honor Code" loads "End User License Agreement" screen
* Verify tapping back icon from "End User License Agreement" screen navigate user back to 'Sign In' screen.
* Verify tapping 'Forgot your password?' will load 'Reset Password' alert
* Verify following contents are visible on 'Reset Password' alert,
** Alert Title
** Alert Message
** Email edit field
** Cancel button
** OK button
* Verify tapping 'Cancel' will close 'Reset Password' alert
* 'is_first_time' should be passed as parameter during login to handle WhatsNew screen properly