### PR TITLE
LEARNER-4932 Test - iOS - Automate Main Dashboard Screen

### DIFF
--- a/common/globals.py
+++ b/common/globals.py
@@ -53,6 +53,17 @@ class Globals(object):
         self.third_existence = 2
         self.fourth_existence = 3
         self.fifth_existence = 4
+        self.sixth_existence = 5
+        self.seventh_existence = 6
+        self.eight_existence = 7
+        self.ninth_existence = 8
+        self.tenth_existence = 9
+        self.eleventh_existence = 10
+        self.twelfth_existence = 11
+        self.thirteenth_existence = 12
+        self.fourteenth_existence = 13
+        self.fifteenth_existence = 14
+        self.sixteenth_existence = 15
 
         self.server_url = environ.get('SERVER_URL')
         self.target_environment = environ.get('TARGET_ENVIRONMENT')
@@ -180,7 +191,7 @@ class Globals(object):
 
         try:
             all_views = WebDriverWait(driver, self.maximum_timeout).until(
-                expected_conditions.visibility_of_all_elements_located((By.CLASS_NAME, target_elements)))
+                expected_conditions.presence_of_all_elements_located((By.CLASS_NAME, target_elements)))
 
             if all_views:
                 no_of_all_views = len(all_views)

--- a/common/strings.py
+++ b/common/strings.py
@@ -1,4 +1,3 @@
-
 """
 All strings accessible in Pages & Tests
 """
@@ -18,6 +17,7 @@ GOOGLE_OPTION = 'Google'
 EULA = 'edX End User License Agreement'
 TERMS = 'edX Terms of Service and Honor Code'
 PRIVACY = 'Privacy Policy'
+SELECTED_BY_DEFAULT = '1'
 
 # NEW LOGISTRATION SCREEN
 NEW_LOGIS_EDX_LOGO = 'edX'
@@ -50,7 +50,6 @@ LOGIN_ANDROID_AGREEMENT = ('By signing in to this app, you agree to the edX End 
                            'of Service and Honor Code and acknowledge the Privacy Policy')
 LOGIN_IOS_AGREEMENT = ('By signing-in to this app, you agree to the edX End User License Agreement and edX Terms '
                        'of Service and Honor Code and acknowledge the Privacy Policy.')
-
 LOGIN_EULA = 'edX End User License Agreement'
 LOGIN_TERMS = 'edX Terms of Service and Honor Code'
 LOGIN_PRIVACY = 'Privacy Policy'
@@ -59,13 +58,17 @@ LOGIN_PRIVACY = 'Privacy Policy'
 WHATS_NEW_DONE = 'Done'
 
 # MAIN DASHBOARD SCREEN
+MAIN_DASHBOARD_PROFILE = 'Pofile'  # Typo from dev side
 MAIN_DASHBOARD_SCREEN_TITLE = 'Courses'
-MAIN_DASHBOARD_FIND_COURSE = 'Find a Course'
 MAIN_DASHBOARD_NAVIGATION_MENU = 'Navigation Menu'
+MAIN_DASHBOARD_COURSES_TAB = 'Courses'
+MAIN_DASHBOARD_DISCOVERY_TAB = 'Discovery'
+MAIN_DASHBOARD_FIND_COURSE = 'Find a Course'
 MAIN_DASHBOARD_NAVIGATION_MENU_NAME = 'Account'
 MAIN_DASHBOARD_NAVIGATION_ACCOUNT_OPTION = 'ACCOUNT'
 
 # ACCOUNT SCREEN
+ACCOUNT_SCREEN_TITLE = 'Account'
 ACCOUNT_LOGOUT = 'Logout'
 
 # REGISTER SCREEN
@@ -104,3 +107,6 @@ NEW_LANDING_MESSAGE_ANDROID = 'Free courses from the world’s best universities
 NEW_LANDING_SEARCH_COURSES = 'Search Courses'
 NEW_LANDING_CREATE_YOUR_ACCOUNT = 'Create your Account'
 NEW_LANDING_LOG_IN = 'Log In'
+
+# PROFILE SCREEN
+PROFILE_SCREEN_TITLE = 'Profile'

--- a/ios/pages/ios_elements.py
+++ b/ios/pages/ios_elements.py
@@ -4,6 +4,7 @@
 all_editfields = 'XCUIElementTypeTextField'
 all_buttons = 'XCUIElementTypeButton'
 all_textviews = 'XCUIElementTypeStaticText'
+all_otherviews = 'XCUIElementTypeOther'
 
 # NEW LOGISTRATION SCREEN
 new_logistration_logo = 'StartUpViewController:logo-image-view'
@@ -56,8 +57,9 @@ whats_new_done_button = 'WhatsNewViewController:done-button'
 # MY DASHBOARD SCREEN
 main_dashboard_title_textview = 'Courses'
 main_dashboard_navigation_icon = 'EnrolledTabBarViewController:account-button'
-main_dashboard_profile_icon = 'Profile'
-main_dashboard_drawer_account_textview = 'ACCOUNT'
+main_dashboard_profile_icon = 'Pofile'  # Typo from dev side
+main_dashboard_courses_tab = 'Courses'
+main_dashboard_discovery_tab = 'Discovery'
 
 # MY ACCOUNT SCREEN
 account_options = 'AccountViewController:title-label'

--- a/ios/pages/ios_main_dashboard.py
+++ b/ios/pages/ios_main_dashboard.py
@@ -25,6 +25,58 @@ class IosMainDashboard(IosBasePage):
             ios_elements.main_dashboard_navigation_icon
         )
 
+    def get_title_textview_portrait_mode(self):
+        """
+        Get screen title
+
+        Returns:
+            webdriver elements List: Screen title textview
+        """
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_otherviews
+        )[self.global_contents.twelfth_existence]
+
+    def get_profile_icon(self):
+        """
+        Get Profile Icon
+
+        Returns:
+            webdriver elements List: Profile icon
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.main_dashboard_profile_icon
+        )
+
+    def get_courses_tab(self):
+        """
+        Get Courses Tab
+
+        Returns:
+            webdriver elements List: Courses Tab
+        """
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_buttons
+        )[self.global_contents.third_existence]
+
+    def get_discovery_tab(self):
+        """
+        Get Discovery Tab
+
+        Returns:
+            webdriver elements List: Discovery tab
+        """
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_buttons
+        )[self.global_contents.fourth_existence]
+
     def get_account_options(self):
         """
         Click on menu drawer icon and get Account Options
@@ -40,6 +92,73 @@ class IosMainDashboard(IosBasePage):
         )
 
         return self.account_options
+
+    def load_profile_screen(self):
+        """
+        Load User Profile Screen
+
+        Returns:
+            webdriver element: Screen title textview
+        """
+
+        self.get_profile_icon().click()
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_otherviews
+        )[self.global_contents.fifteenth_existence]
+
+    def load_discovery_tab(self):
+        """
+        Load Discovery
+
+        Returns:
+            webdriver elements : Discovery Tab textview
+        """
+
+        self.get_discovery_tab().click()
+
+        return self.get_discovery_tab()
+
+    def load_courses_tab(self):
+        """
+        Load Courses
+
+        Returns:
+            webdriver elements : Courses Tab textview
+        """
+
+        self.get_courses_tab().click()
+
+        return self.get_courses_tab()
+
+    def load_account_screen(self):
+        """
+        Load Account Screen
+
+        Returns:
+            webdriver element: Screen title textview
+        """
+
+        self.get_drawer_icon().click()
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_otherviews
+        )[self.global_contents.fifteenth_existence]
+
+    def get_title_textview_landscape_mode(self):
+        """
+        Get screen title
+
+        Returns:
+            webdriver elements List: Screen title textview
+        """
+
+        return self.global_contents.get_all_views_on_ios_screen(
+            self.driver,
+            ios_elements.all_otherviews
+        )[self.global_contents.sixth_existence]
 
     def log_out(self):
         """

--- a/ios/tests/test_ios_main_dashboard.py
+++ b/ios/tests/test_ios_main_dashboard.py
@@ -33,26 +33,59 @@ class TestIosMainDashboard(object):
         else:
             assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
 
-    def test_validate_ui_elements(self, set_capabilities, setup_logging):
+    def test_validate_ui_elements_smoke(self, set_capabilities, setup_logging):
         """
         Scenarios:
                 Verify following contents are visible on screen, 
-                     Screen Title, Menu Drawer, Account Menu option and Log out user
-                Verify all screen contents have their default values
+                    Logged in user's avatar, Screen Title, Account Icon
+                    Courses Tab, Discovery Tab
+                Verify that Courses tab will be selected by default
+        """
+
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+
+        assert ios_main_dashboard_page.get_profile_icon().text == strings.MAIN_DASHBOARD_PROFILE
+        assert ios_main_dashboard_page.get_title_textview_portrait_mode().text == strings.MAIN_DASHBOARD_SCREEN_TITLE
+        assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
+        assert ios_main_dashboard_page.get_courses_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+
+    def test_load_contents_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+                Verify on tapping Courses will load Courses contents in its tab
+                Verify on tapping Discovery will load Discovery contents in its tab
+                Verify tapping user's avatar will load User Profile screen
+                Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
+                Verify tapping Account Icon will load Account Screen
+                Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen
+        """
+
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+
+        assert ios_main_dashboard_page.load_discovery_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
+
+        assert ios_main_dashboard_page.load_courses_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+
+        assert ios_main_dashboard_page.load_profile_screen().text == strings.PROFILE_SCREEN_TITLE
+        set_capabilities.back()
+
+        assert ios_main_dashboard_page.load_account_screen().text == strings.ACCOUNT_SCREEN_TITLE
+        set_capabilities.back()
+
+    def test_logout_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenario:
                 Verify that user can log out successfully, and back on Login screen
         """
 
         ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
         global_contents = Globals(setup_logging)
 
-        # Commenting it temporarily, it should be fix with LEARNER-4409
-        # textview_screen_title = ios_main_dashboard_page.get_title_textview()
-        # assert textview_screen_title.text == strings.MAIN_DASHBOARD_SCREEN_TITLE
-
-        assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
         assert ios_main_dashboard_page.get_account_options()[3].text == strings.ACCOUNT_LOGOUT
         assert ios_main_dashboard_page.log_out().text == strings.LOGIN
-
         setup_logging.info('{} is successfully logged out'.format(global_contents.login_user_name))
 
     def test_landscape_smoke(self, set_capabilities, setup_logging):
@@ -60,10 +93,16 @@ class TestIosMainDashboard(object):
         Scenarios:
                 Landscape support is added for Main Dashboard screen with following cases,
                 Change device orientation to Landscape mode
-                Verify Main Dashboard screen is loaded successfully
                 Verify following contents are visible on screen, 
-                     Screen Title, Menu Drawer, Account Menu option and Log out user
-                Verify all screen contents have their default values
+                    Logged in user's avatar, Screen Title, Account Icon
+                    Courses Tab, Discovery Tab
+                Verify that Courses tab will be selected by default
+                Verify on tapping Courses will load Courses contents in its tab
+                Verify on tapping Discovery will load Discovery contents in its tab
+                Verify tapping user's avatar will load User Profile screen
+                Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
+                Verify tapping Account Icon will load Account Screen
+                Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen
                 Verify that user can log out successfully, and back on Login screen
         """
 
@@ -75,7 +114,22 @@ class TestIosMainDashboard(object):
         setup_logging.info('{} is successfully logged in'.format(global_contents.login_user_name))
 
         global_contents.turn_orientation(set_capabilities, global_contents.LANDSCAPE_ORIENTATION)
+
+        assert ios_main_dashboard_page.get_profile_icon().text == strings.MAIN_DASHBOARD_PROFILE
+        assert ios_main_dashboard_page.get_title_textview_landscape_mode().text == strings.MAIN_DASHBOARD_SCREEN_TITLE
         assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
+        assert ios_main_dashboard_page.get_courses_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+
+        assert ios_main_dashboard_page.load_discovery_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
+        assert ios_main_dashboard_page.load_courses_tab().text == strings.SELECTED_BY_DEFAULT
+        assert ios_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+        assert ios_main_dashboard_page.load_profile_screen().text == strings.PROFILE_SCREEN_TITLE
+        set_capabilities.back()
+        assert ios_main_dashboard_page.load_account_screen().text == strings.ACCOUNT_SCREEN_TITLE
+        set_capabilities.back()
+
         assert ios_main_dashboard_page.get_account_options()[3].text == strings.ACCOUNT_LOGOUT
         assert ios_main_dashboard_page.log_out().text == strings.LOGIN
         setup_logging.info('{} is successfully logged out'.format(global_contents.login_user_name))


### PR DESCRIPTION
Following cases have been handled

* Verify following contents are visible on screen, 
** Logged in user avatar
** Screen Title
** Account Icon
** Courses Tab
** Discovery Tab
* Verify on tapping Courses will load Courses contents in its tab
* Verify on tapping Discovery will load Discovery contents in its tab
* Verify tapping user avatar will load User Profile screen
* Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
* Verify tapping Account Icon will load Account Screen
* Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen
* Above all cases are also integrated into Landscape Mode,
* Verify following contents are visible on screen, 
** Logged in user avatar
** Screen Title
** Account Icon
** Courses Tab
** Discovery Tab
* Verify that Courses tab will be selected by default
* Verify on tapping Courses will load Courses contents in its tab
* Verify on tapping Discovery will load Discovery contents in its tab
* Verify tapping user avatar will load User Profile screen
* Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
* Verify tapping Account Icon will load Account Screen
* Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen