### PR TITLE
Learner 5680 Test - Android - Implement landscape support on Main Dashboard Screen

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,2 @@
 [pep8]
 max_line_length=119
-exclude=testdata

--- a/android/tests/test_android_main_dashboard.py
+++ b/android/tests/test_android_main_dashboard.py
@@ -2,7 +2,9 @@
 """
     Main Dashboard Test Module
 """
+from android.pages.android_login import AndroidLogin
 from android.pages.android_main_dashboard import AndroidMainDashboard
+from android.pages.android_new_landing import AndroidNewLanding
 from android.pages.android_whats_new import AndroidWhatsNew
 from common.globals import Globals
 from common import strings
@@ -60,10 +62,9 @@ class TestAndroidMainDashboard(object):
         global_contents = Globals(setup_logging)
 
         assert android_main_dashboard_page.load_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+        assert android_main_dashboard_page.load_discovery_tab().is_selected()
         assert android_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
-
-        assert android_main_dashboard_page.load_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
-        assert android_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+        assert android_main_dashboard_page.load_courses_tab().is_selected()
 
         assert android_main_dashboard_page.load_profile_screen() == global_contents.PROFILE_ACTIVITY_NAME
         set_capabilities.back()
@@ -82,5 +83,59 @@ class TestAndroidMainDashboard(object):
 
         assert android_main_dashboard_page.log_out() == global_contents.DISCOVERY_LAUNCH_ACTIVITY_NAME
         setup_logging.info('{} is successfully logged out'.format(global_contents.login_user_name))
+
+        setup_logging.info('-- Ending {} Test Case'.format(TestAndroidMainDashboard.__name__))
+
+    def test_landscape_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+                Landscape support is added for Main Dashboard screen with following cases,
+                Change device orientation to Landscape mode
+                Verify following contents are visible on screen, 
+                    Logged in user's avatar, Screen Title, Account Icon
+                    Courses Tab, Discovery Tab
+                Verify that Courses tab will be selected by default
+                Verify on tapping Courses will load Courses contents in its tab
+                Verify on tapping Discovery will load Discovery contents in its tab
+                Verify tapping user's avatar will load User Profile screen
+                Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
+                Verify tapping Account Icon will load Account Screen
+                Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen
+                Verify that user can log out successfully, and back on Login screen
+        """
+
+        global_contents = Globals(setup_logging)
+        android_main_dashboard_page = AndroidMainDashboard(set_capabilities, setup_logging)
+        android_new_landing_page = AndroidNewLanding(set_capabilities, setup_logging)
+        android_login_page = AndroidLogin(set_capabilities, setup_logging)
+
+        assert android_new_landing_page.on_screen() == Globals.DISCOVERY_LAUNCH_ACTIVITY_NAME
+        assert android_new_landing_page.load_login_screen() == Globals.LOGIN_ACTIVITY_NAME
+        login_output = android_login_page.login(
+            global_contents.login_user_name,
+            global_contents.login_password, False)
+        setup_logging.info('{} is successfully logged in'.format(global_contents.login_user_name))
+        assert login_output == Globals.MAIN_DASHBOARD_ACTIVITY_NAME
+
+        global_contents.turn_orientation(set_capabilities, global_contents.LANDSCAPE_ORIENTATION)
+
+        assert android_main_dashboard_page.get_profile_icon().text == strings.BLANK_FIELD
+        assert android_main_dashboard_page.get_title_textview().text == strings.MAIN_DASHBOARD_SCREEN_TITLE
+        assert android_main_dashboard_page.get_menu_icon().text == strings.BLANK_FIELD
+        assert android_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
+        assert android_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+
+        assert android_main_dashboard_page.load_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
+        assert android_main_dashboard_page.load_discovery_tab().is_selected()
+        assert android_main_dashboard_page.load_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
+        assert android_main_dashboard_page.load_courses_tab().is_selected()
+        assert android_main_dashboard_page.load_profile_screen() == global_contents.PROFILE_ACTIVITY_NAME
+        set_capabilities.back()
+        assert android_main_dashboard_page.load_account_screen() == global_contents.ACCOUNT_ACTIVITY_NAME
+        set_capabilities.back()
+
+        assert android_main_dashboard_page.log_out() == global_contents.DISCOVERY_LAUNCH_ACTIVITY_NAME
+        setup_logging.info('{} is successfully logged out'.format(global_contents.login_user_name))
+        global_contents.turn_orientation(set_capabilities, global_contents.PORTRAIT_ORIENTATION)
 
         setup_logging.info('-- Ending {} Test Case'.format(TestAndroidMainDashboard.__name__))

--- a/common/globals.py
+++ b/common/globals.py
@@ -463,7 +463,7 @@ class Globals(object):
         if driver.orientation == target_orientation:
             self.project_log.info('{} is already set '.format(target_orientation))
         else:
-            self.project_log.info('{} turning orientation to '.format(target_orientation))
+            self.project_log.info('Turning orientation to {}'.format(target_orientation))
             driver.orientation = target_orientation
 
     def generate_random_credentials(self, length):

--- a/common/strings.py
+++ b/common/strings.py
@@ -107,10 +107,6 @@ DISCOVER_SUBJECTS_SECTION_TITLE = 'Browse By Subject'
 MY_COURSES_LIST_FIND_COURSES_MESSAGE = 'Looking for a new challenge?'
 MY_COURSES_LIST_FIND_COURSES_BUTTON = 'FIND A COURSE'
 
-# MY COURSES LIST
-MY_COURSES_LIST_FIND_COURSES_MESSAGE = 'Looking for a new challenge?'
-MY_COURSES_LIST_FIND_COURSES_BUTTON = 'FIND A COURSE'
-
 # NEW LANDING SCREEN
 NEW_LANDING_MESSAGE_IOS = 'Free courses from the world\'s best universities in your pocket.'
 NEW_LANDING_MESSAGE_ANDROID = 'Free courses from the world’s best universities in your pocket.'

--- a/ios/pages/ios_my_courses_list.py
+++ b/ios/pages/ios_my_courses_list.py
@@ -52,12 +52,12 @@ class IosMyCoursesList(IosBasePage):
             webdriver element: My Course name Element
         """
 
-        coruse_name = self.global_contents.get_all_views_on_ios_screen(
+        course_name = self.global_contents.get_all_views_on_ios_screen(
             self.driver,
             ios_elements.my_courses_list_course_name
         )
 
-        return coruse_name[1] if coruse_name[1] else coruse_name[1]
+        return course_name[1] if course_name[1] else course_name[1]
 
     def get_my_course_details(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
 [pep8]
 max_line_length=119
-exclude=testdata


### PR DESCRIPTION
Landscape support is added for Main Dashboard screen with following cases,
    * Change device orientation to Landscape mode
    * Verify following contents are visible on screen, 
    ** Logged in user"s avatar
    ** Screen Title
    ** Account Icon
    ** Courses Tab
    ** Discovery Tab
    * Verify that Courses tab will be selected by default
    * Verify on tapping Courses will load Courses contents in its tab
    * Verify on tapping Discovery will load Discovery contents in its tab
    * Verify tapping user"s avatar will load User Profile screen
    * Verify tapping back/cancel icon from User Profile screen should get back to Main Dashboard screen
    * Verify tapping Account Icon will load Account Screen
    * Verify tapping back/cancel icon from Account Screen should get back to Main Dashboard screen
    * Verify that user can log out successfully, and back on Login screen* Verify that user can log out successfully, and back on Login screen
* Typo in ios_my_courses_list.py page
* Removed un-necessary "exclude=testdata" value from pep8, as it is no more needed
* Removed un-necessary "exclude=testdata" value from setup, as it is no more needed