### PR TITLE
feat: Automate course Videos dashboard screen

### DIFF
--- a/tests/ios/pages/ios_elements.py
+++ b/tests/ios/pages/ios_elements.py
@@ -66,7 +66,7 @@ account_view_close_button = 'AccountViewController:close-button'
 
 # MY COURSES LIST SCREEN
 my_courses_list = 'courses-table-view'  # XCUIElementTypeTable
-my_courses_list_course_row = 'XCUIElementTypeCell'
+my_courses_list_course_row = 'CourseCardCell:course-card-view'
 my_courses_list_course_image = ''
 my_courses_list_course_name = 'XCUIElementTypeStaticText'
 my_courses_list_course_details = 'XCUIElementTypeStaticText'
@@ -168,3 +168,7 @@ course_dashboard_resume_row = 'CourseOutlineHeaderView:view-button'
 course_subsection_download_icon = 'CourseVideoTableViewCell:download-view'
 course_subsection_html_cell = 'CourseHTMLTableViewCell:view'
 course_subsection_video_cell = 'CourseVideoTableViewCell:view'
+
+# COURSE_VIDEO_DASHBOARD
+video_dashboard_download_switch = 'CourseVideosHeader:toggle-switch'
+video_dashboard_download_header = 'CourseVideosHeader:show-downloads-button'

--- a/tests/ios/pages/ios_my_courses_list.py
+++ b/tests/ios/pages/ios_my_courses_list.py
@@ -37,10 +37,7 @@ class IosMyCoursesList(IosBasePage):
             ios_elements.my_courses_list_course_row
         )
 
-        if courses_row[1]:
-            return courses_row[1]
-        else:
-            return courses_row
+        return courses_row[1] if courses_row[1] else courses_row
 
     def get_my_course_name(self):
         """

--- a/tests/ios/pages/ios_my_courses_list.py
+++ b/tests/ios/pages/ios_my_courses_list.py
@@ -32,13 +32,13 @@ class IosMyCoursesList(IosBasePage):
             webdriver element: My Course row Element
         """
 
-        courses_row = self.global_contents.get_all_views_on_ios_screen(
+        courses_row = self.global_contents.get_all_elements_by_id(
             self.driver,
             ios_elements.my_courses_list_course_row
         )
 
-        if courses_row:
-            return courses_row[0]
+        if courses_row[1]:
+            return courses_row[1]
         else:
             return courses_row
 
@@ -50,12 +50,12 @@ class IosMyCoursesList(IosBasePage):
             webdriver element: My Course name Element
         """
 
-        course_name = self.global_contents.get_all_views_on_ios_screen(
+        course_name = self.global_contents.get_all_elements_by_id(
             self.driver,
             ios_elements.my_courses_list_course_row
         )
 
-        return course_name[0] if course_name[0] else course_name[0]
+        return course_name[1] if course_name[1] else course_name[0]
 
     def get_my_course_details(self):
         """
@@ -116,7 +116,7 @@ class IosMyCoursesList(IosBasePage):
             ios_elements.all_textviews
         )
 
-        return course_details[0] if course_details[0] else course_details[0]
+        return course_details[1] if course_details[1] else course_details[0]
 
     def load_discovery_screen(self):
         """

--- a/tests/ios/pages/ios_videos_dashboard.py
+++ b/tests/ios/pages/ios_videos_dashboard.py
@@ -23,7 +23,7 @@ class IosVideosDashboard(IosBasePage):
             self.driver,
             ios_elements.video_dashboard_download_switch
         )
-        
+
     def get_video_download_header(self):
         """
         Get video download header

--- a/tests/ios/pages/ios_videos_dashboard.py
+++ b/tests/ios/pages/ios_videos_dashboard.py
@@ -1,0 +1,38 @@
+"""
+    Course Dashboard Page Module
+"""
+
+from tests.ios.pages import ios_elements
+from tests.ios.pages.ios_base_page import IosBasePage
+
+
+class IosVideosDashboard(IosBasePage):
+    """
+    Course Dashboard screen
+    """
+
+    def get_video_download_switch(self):
+        """
+        Get video download switch
+
+        Returns:
+            webdriver element: video download switch element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.video_dashboard_download_switch
+        )
+        
+    def get_video_download_header(self):
+        """
+        Get video download header
+
+        Returns:
+            webdriver element: video download header element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.video_dashboard_download_header
+        )

--- a/tests/ios/tests/test_ios_videos_dashboard.py
+++ b/tests/ios/tests/test_ios_videos_dashboard.py
@@ -1,0 +1,103 @@
+"""
+    Course Dashboard Test Module
+"""
+
+
+from tests.common import strings
+from tests.common.globals import Globals
+from tests.ios.pages.ios_main_dashboard import IosMainDashboard
+from tests.ios.pages.ios_my_courses_list import IosMyCoursesList
+from tests.ios.pages.ios_course_dashboard import IosCourseDashboard
+from tests.ios.pages.ios_whats_new import IosWhatsNew
+from tests.ios.pages.ios_videos_dashboard import IosVideosDashboard
+
+
+class TestIosCourseVideosDashboard:
+    """
+    Course Videos Dashboard screen's Test Case
+
+    """
+
+    def test_start_main_dashboard_smoke(self, login, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify Main Dashboard screen is loaded successfully after successful login
+        """
+
+        global_contents = Globals(setup_logging)
+
+        setup_logging.info('-- Starting Test Case --')
+        if login:
+            setup_logging.info('{} is successfully logged in'.format(global_contents.login_user_name))
+
+        ios_whats_new_page = IosWhatsNew(set_capabilities, setup_logging)
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+
+        if global_contents.is_first_time:
+            assert ios_whats_new_page.exit_features().text == strings.BLANK_FIELD
+        else:
+            assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
+
+    def test_validate_ui_elements_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify that from My Courses list tapping any Course will load Course
+            Dashboard screen/contents(of this specific course) in its tab
+        """
+
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+        ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
+        ios_my_courses_list = IosMyCoursesList(set_capabilities, setup_logging)
+
+        assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
+        if ios_my_courses_list.get_my_courses_list_row():
+            course_name = ios_my_courses_list.get_my_courses_list_row().text
+            assert ios_my_courses_list.load_course_details_screen().text
+        assert ios_course_dashboard_page.get_course_title().text in course_name
+
+    def test_load_contents_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify on tapping "Discussion" tab will load Discussions screen
+            Verify on tapping "Dates" tab will load Dates screen
+            Verify on tapping "Resources" tab will load Resources list
+            Verify on tapping "Videos" tab will load Videos screen
+            Verify that Course Videos Dashboard screen will show following contents,
+                Header contents, Back icon, Specific "<course name>" as Title, Share icon,
+                Footer Content,
+                        Course, Videos, Discussion, Dates, Resources
+            Verify that user should be able to view these contents:
+                videos download header,
+                Videos download switch
+        """
+
+        global_contents = Globals(setup_logging)
+        ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
+        ios_videos_dashboard_page = IosVideosDashboard(set_capabilities, setup_logging)
+
+        assert ios_course_dashboard_page.get_courses_tab().text == global_contents.is_selected
+        assert ios_course_dashboard_page.get_discussion_tab().text == strings.COURSE_DASHBOARD_DISCUSSION_TAB
+        ios_course_dashboard_page.load_discussion_tab()
+        assert ios_course_dashboard_page.get_discussion_tab().text == global_contents.is_selected
+        assert ios_course_dashboard_page.get_dates_tab().text == strings.COURSE_DASHBOARD_DATES_TAB
+        ios_course_dashboard_page.load_dates_tab()
+        assert ios_course_dashboard_page.get_dates_tab().text == global_contents.is_selected
+        assert ios_course_dashboard_page.get_resources_tab().text == strings.COURSE_DASHBOARD_RESOURCES_TAB
+        ios_course_dashboard_page.load_resources_tab()
+        assert ios_course_dashboard_page.get_handouts_row_title().text == strings.COURSE_DASHBOARD_HANDOUTS_TITLE
+        assert ios_course_dashboard_page.get_handouts_row_name().text == strings.COURSE_DASHBOARD_HANDOUTS_ROW
+
+        assert ios_course_dashboard_page.get_videos_tab().text == strings.COURSE_DASHBOARD_VIDEOS_TAB
+        ios_course_dashboard_page.load_videos_tab()
+        assert ios_course_dashboard_page.get_videos_tab().text == global_contents.is_selected
+
+        assert ios_course_dashboard_page.get_share_icon().text == strings.COURSE_DASHBOARD_SHARE_COURSE
+        assert ios_course_dashboard_page.get_course_section_header()
+        assert ios_course_dashboard_page.get_course_item_title()
+        assert ios_course_dashboard_page.get_course_item_download_icon()
+
+        assert ios_videos_dashboard_page.get_video_download_switch()
+        ios_videos_dashboard_page.get_video_download_switch()
+
+        assert ios_videos_dashboard_page.get_video_download_header()
+        setup_logging.info('-- Ending Test Case --')

--- a/tests/ios/tests/test_ios_videos_dashboard.py
+++ b/tests/ios/tests/test_ios_videos_dashboard.py
@@ -55,7 +55,7 @@ class TestIosCourseVideosDashboard:
             assert ios_my_courses_list.load_course_details_screen().text
         assert ios_course_dashboard_page.get_course_title().text in course_name
 
-    def test_load_contents_smoke(self, set_capabilities, setup_logging):
+    def test_videos_dashboard_navigations(self, set_capabilities, setup_logging):
         """
         Scenarios:
             Verify on tapping "Discussion" tab will load Discussions screen
@@ -63,17 +63,10 @@ class TestIosCourseVideosDashboard:
             Verify on tapping "Resources" tab will load Resources list
             Verify on tapping "Videos" tab will load Videos screen
             Verify that Course Videos Dashboard screen will show following contents,
-                Header contents, Back icon, Specific "<course name>" as Title, Share icon,
-                Footer Content,
-                        Course, Videos, Discussion, Dates, Resources
-            Verify that user should be able to view these contents:
-                videos download header,
-                Videos download switch
         """
 
         global_contents = Globals(setup_logging)
         ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
-        ios_videos_dashboard_page = IosVideosDashboard(set_capabilities, setup_logging)
 
         assert ios_course_dashboard_page.get_courses_tab().text == global_contents.is_selected
         assert ios_course_dashboard_page.get_discussion_tab().text == strings.COURSE_DASHBOARD_DISCUSSION_TAB
@@ -90,6 +83,20 @@ class TestIosCourseVideosDashboard:
         assert ios_course_dashboard_page.get_videos_tab().text == strings.COURSE_DASHBOARD_VIDEOS_TAB
         ios_course_dashboard_page.load_videos_tab()
         assert ios_course_dashboard_page.get_videos_tab().text == global_contents.is_selected
+
+    def test_load_contents_smoke(self, set_capabilities, setup_logging):
+        """
+        Verify that Course Videos Dashboard screen will show following contents,
+            Header contents, Back icon, Specific "<course name>" as Title, Share icon,
+            Footer Content,
+                    Course, Videos, Discussion, Dates, Resources
+        Verify that user should be able to view these contents:
+            videos download header,
+            Videos download switch
+        """
+
+        ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
+        ios_videos_dashboard_page = IosVideosDashboard(set_capabilities, setup_logging)
 
         assert ios_course_dashboard_page.get_share_icon().text == strings.COURSE_DASHBOARD_SHARE_COURSE
         assert ios_course_dashboard_page.get_course_section_header()


### PR DESCRIPTION
[LEARNER-7791](https://openedx.atlassian.net/browse/LEARNER-7791)

**Description**

Verify that from My Courses list tapping any Course will load Course
Dashboard screen/contents(of this specific course) in its tab
Verify on tapping "Discussion" tab will load Discussions screen
Verify on tapping "Dates" tab will load Dates screen
Verify on tapping "Resources" tab will load Resources list
Verify on tapping "Videos" tab will load Videos screen
Verify that the Course Videos Dashboard screen will show the following contents,
Header contents, Back icon, Specific "<course name>" as Title, Share icon,
Footer Content,
Course, Videos, Discussion, Dates, Resources
Verify that the user should be able to view these contents:
videos download header,
Videos download switch